### PR TITLE
Update HTML doc generation settings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,8 @@
 defmodule ReadingTime.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/iaguirre88/reading_time"
+
   def project do
     [
       app: :reading_time,
@@ -9,7 +11,8 @@ defmodule ReadingTime.MixProject do
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
-      deps: deps()
+      deps: deps(),
+      docs: docs()
     ]
   end
 
@@ -25,25 +28,33 @@ defmodule ReadingTime.MixProject do
       maintainers: ["Ignacio Aguirrezabal"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/iaguirre88/reading_time",
+        "GitHub" => @source_url,
         "Docs" => "https://hexdocs.pm/reading_time"
       }
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger]
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
       {:stream_data, "~> 0.5", only: :test}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      source_url: @source_url,
+      extras: [
+        "README.md"
+      ]
     ]
   end
 end


### PR DESCRIPTION
This PR updates the HTML doc generation by:

1. Add link to Github source code from HTML doc.
2. Make README the default page in HTML doc.